### PR TITLE
Added API KEY logic to app.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+API_KEY.txt

--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ var bodyParser = require ('body-parser');
 
 app.use(morgan('dev'));
 
+const API_KEY = fs.readFileSync("./API_KEY.txt").toString(); //This is your API key
 
 // Very basic example of app.get (URL, function (requestObject, responseObject))
 // app.get ('/', function (req, res)


### PR DESCRIPTION
This pull request is to enable the project to use an API Key, while not disclosing that information publicly. Create a file called API_KEY.txt in the root branch (locally) and paste the API key into that file. app.js will read this file and store it in the variable `API_KEY`